### PR TITLE
feat(SleepClient): better sleep count

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ class Config implements ConfigContract
         // if you want to pass an object reference from the default configuration
         /** @see \StrictPhp\HttpClients\Clients\CacheResponse\Config */
         
-        // or
+        // or empty
         /** @see \StrictPhp\HttpClients\Clients\Sleep\Config */
     }
     

--- a/src/Clients/Event/Entities/HttpStateEntity.php
+++ b/src/Clients/Event/Entities/HttpStateEntity.php
@@ -24,13 +24,13 @@ final class HttpStateEntity
         public readonly RequestInterface $request,
     )
     {
-        $this->start = Time::micro();
+        $this->start = Time::seconds();
         $this->id = md5($this->start . $this->request->getUri());
     }
 
     public function finish(): self
     {
-        $this->end = Time::micro();
+        $this->end = Time::seconds();
         $this->duration = $this->end - $this->start;
 
         return $this;

--- a/src/Clients/Sleep/Config.php
+++ b/src/Clients/Sleep/Config.php
@@ -7,8 +7,8 @@ use StrictPhp\HttpClients\Contracts\ConfigContract;
 final class Config implements ConfigContract
 {
     public function __construct(
-        public readonly int $from = 500,
-        public readonly int $to = 1000,
+        public readonly int $from = 500, // milliseconds
+        public readonly int $to = 1000, // milliseconds
     ) {
     }
 

--- a/src/Clients/Sleep/SleepClient.php
+++ b/src/Clients/Sleep/SleepClient.php
@@ -28,17 +28,16 @@ final class SleepClient implements ClientInterface
         $config = $this->configManager->get(Config::class, $host);
 
         if ($config->to > 0 && isset($this->timeout[$host])) {
-            $diff = Time::micro() - $this->timeout[$host];
-            if ($diff < 1) {
-                Time::sleep(random_int($config->from, $config->to));
-            }
+            $diff = (int) (Time::milli() - $this->timeout[$host]);
+            $sleep = random_int($config->from, $config->to);
+            Time::sleep($sleep - $diff);
         }
 
         try {
             $response = $this->client->sendRequest($request);
         } finally {
             if ($config->to > 0) {
-                $this->timeout[$host] = Time::micro();
+                $this->timeout[$host] = Time::milli();
             }
         }
 

--- a/src/Helpers/Time.php
+++ b/src/Helpers/Time.php
@@ -4,13 +4,20 @@ namespace StrictPhp\HttpClients\Helpers;
 
 final class Time
 {
-    public static function micro(): float
+    public static function seconds(): float
     {
         return microtime(true);
     }
 
+    public static function milli(): float
+    {
+        return self::seconds() * 1000;
+    }
+
     public static function sleep(int $milliSeconds): void
     {
-        usleep($milliSeconds * 1000);
+        if ($milliSeconds > 0) {
+            usleep($milliSeconds * 1000);
+        }
     }
 }


### PR DESCRIPTION
Předchozí chování:
Vypočítal se rozdíl v sekundách a pokud byl čas pod 1s tak se počítalo s uspání na náhodnou celou dobu z intervalu.
- chyba byla pokud by jsi chtěl uspat na více jak 1s a pak si myslím že se může odečíst doba běhu aplikace

nyní se počítá rozdíl v milisekundách, zjistí se interval na uspání a pokud ten interval je menší než předchozí rozdíl, tak se ani uspávat nebude, v opačném případě se rozdíl odečte a uspí